### PR TITLE
Add "Getting the mnemonic" first step to "Wallet Setup" page

### DIFF
--- a/vocs-docs/docs/pages/interaction/wallet-setup.mdx
+++ b/vocs-docs/docs/pages/interaction/wallet-setup.mdx
@@ -1,12 +1,6 @@
 # Wallet Setup
 
-To manage your accounts, issue orders, and perform other operations that are required to be signed, a Wallet is required.
-
-A Wallet is setup using your secret __mnemonic__ phrase. Please see this [guide](/todo) on how to get it.
-
-:::warning
-Handle your __mnemonic__ in a secure manner. __Do not share__ it with other parties. Access to your __mnemonic__ provides access to your account and funds. 
-:::
+To manage your accounts, issue orders, and perform other operations that are required to be signed, a Wallet is required. To instantiate a Wallet, you must first have your associated __mnemonic__.
 
 :::details[Unification Plan]
 - The Python client requires the use of an address to setup the Wallet. However, the address can only be fetched using a Wallet. The address is derived from the mnemonic (address < public key < private key < mnemonic).
@@ -18,10 +12,21 @@ Handle your __mnemonic__ in a secure manner. __Do not share__ it with other part
 
 ::::steps
 
+## Getting the mnemonic
+
+A Wallet is setup using your secret __mnemonic__ phrase. A __mnemonic__ is a set of 24 words to back up and access your account.
+
+You can fetch your __mnemonic__ from the [dYdX Frontend](https://dydx.trade). After logging in, follow the instructions in "Export secret phrase", accessed by clicking your address in the upper right corner.
+
+For the purpose of this guide, lets copy and store the __mnemonic__ in a `mnemonic.txt` file. 
+
+:::warning
+Handle your __mnemonic__ in a secure manner. __Do not share__ it with other parties. Do not commit your __mnemonic__ to a public VCS like GitHub. Access to your __mnemonic__ provides access to your account and funds. 
+:::
 
 ## Read the mnemonic
 
-Load the mnemonic into a string variable. This assumes the mnemonic is stored in a text file.
+Lets start coding. Load the mnemonic into a string variable. This assumes the mnemonic is stored in a text file.
 
 :::code-group
 
@@ -84,7 +89,7 @@ This step is not required in the Python client.
 :::
 
 When issuing orders, the relevant Subaccount must be chosen to place the order under. A Subaccount is associated with an Account, and is meant to provide trade isolation against your other Subaccounts and enhance funds management.
-See more about accounts and subaccounts [here](/todo).
+See more about [Accounts and Subaccounts](/concepts/trading/accounts).
 
 :::code-group
 


### PR DESCRIPTION
How to get the mnemonic, added to the Wallet Setup.

It would be cool to show how to derive new mnemonics locally, though dYdX requires some account activation (maybe some transaction is sent) which I'm not sure how it is done.

The method shown here is the only method dYdX shows in the docs and requires logging into the frontend (web version).