### PR TITLE
Remove pnpm workspace

### DIFF
--- a/vocs-docs/pnpm-workspace.yaml
+++ b/vocs-docs/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-ignoredBuiltDependencies:
-  - esbuild


### PR DESCRIPTION
`pnpm dev` doesn't work if a workspace config is not complete