### PR TITLE
Add batch cancel, deposit, transfer, withdraw methods to index

### DIFF
--- a/vocs-docs/docs/pages/node-client/private/batch_cancel_orders.mdx
+++ b/vocs-docs/docs/pages/node-client/private/batch_cancel_orders.mdx
@@ -1,8 +1,6 @@
 ### Batch Cancel Orders
 
-Cancel a batch of short-terms [Orders].
-
-[Orders]: https://docs.rs/dydx-proto/0.2.0/x86_64-unknown-linux-gnu/dydx_proto/dydxprotocol/clob/struct.Order.html
+Cancel a batch of short-terms orders.
 
 #### Method Declaration
 
@@ -20,7 +18,12 @@ async def batch_cancel_orders(
 ```
 
 ```typescript [TypeScript]
-TODO: batchCancelShortTermOrders
+async batchCancelShortTermOrdersWithMarketId(
+  subaccount: SubaccountInfo,
+  shortTermOrders: OrderBatchWithMarketId[],
+  goodTilBlock: number,
+  broadcastMode?: BroadcastMode,
+): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx>
 ```
 
 ```rust [Rust]
@@ -34,13 +37,13 @@ pub async fn batch_cancel_orders(
 ```
 
 ```url [API]
+/dydxprotocol.clob.Msg/BatchCancel
 ```
 
 :::
 
 :::details[Unification Plan]
 - `TxOptions` is not available in Rust
-- No implementation if TypeScript?
 :::
 
 #### Parameters
@@ -57,7 +60,7 @@ pub async fn batch_cancel_orders(
 
 | Status | Meaning     | Schema   |
 | ------ | ----------- | -------- |
-| `200`  | [OK]        | [String] |
+| `200`  | [OK]        | [TxHash] |
 
 Examples: [Python] | [TypeScript] | [Rust]
 
@@ -66,6 +69,7 @@ Examples: [Python] | [TypeScript] | [Rust]
 [Rust]:https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-rs/client/examples/batch_cancel_orders.rs
 
 [Wallet]: /types/wallet
+[OK]: /types/ok
 [SubaccountId]: /types/subaccount_id
 [OrderBatch]: /types/order_batch
 [TxOptions]: /types/tx_options

--- a/vocs-docs/docs/pages/node-client/private/deposit.mdx
+++ b/vocs-docs/docs/pages/node-client/private/deposit.mdx
@@ -18,7 +18,12 @@ async def deposit(
 ```
 
 ```typescript [TypeScript]
-TODO: Deposit
+async deposit(
+  subaccount: SubaccountInfo,
+  assetId: number,
+  quantums: Long,
+  broadcastMode?: BroadcastMode,
+): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx>
 ```
 
 ```rust [Rust]
@@ -32,6 +37,7 @@ pub async fn deposit(
 ```
 
 ```url [API]
+/dydxprotocol.sending.Msg/DepositToSubaccount
 ```
 
 :::
@@ -51,9 +57,11 @@ pub async fn deposit(
 
 #### Response
 
-| Status | Meaning     | Schema |
-| ------ | ----------- | ------ |
-| `200`  | [OK]        | string |
+| Status | Meaning     | Schema   |
+| ------ | ----------- | -------- |
+| `200`  | [OK]        | [TxHash] |
 
 [Wallet]: /types/wallet
 [SubaccountId]: /types/Subaccount_id
+[OK]: /types/ok
+[TxHash]: /types/tx_hash

--- a/vocs-docs/docs/pages/node-client/private/index.mdx
+++ b/vocs-docs/docs/pages/node-client/private/index.mdx
@@ -25,16 +25,17 @@ import QueryTransactionResult from './query_transaction_result.mdx'
 
 <PlaceOrder />
 <CancelOrder />
+<BatchCancelOrders />
+<Deposit />
+<Withdraw />
+<Transfer />
 <SendToken />
+<SendTokenIbc />
 <Simulate />
+<CreateTransaction />
 <BroadcastTransaction />
 <CreateMarketPermissionless />
-<CreateTransaction />
 <Delegate />
-<QueryAddress />
-<QueryTransaction />
-<QueryTransactionResult />
-<RegisterAffiliate />
-<SendTokenIbc />
 <Undelegate />
+<RegisterAffiliate />
 <WithdrawDelegatorReward />

--- a/vocs-docs/docs/pages/node-client/private/send_token_ibc.mdx
+++ b/vocs-docs/docs/pages/node-client/private/send_token_ibc.mdx
@@ -1,17 +1,17 @@
-### Send Token Ibc
+### Send Token IBC
 
-Transfer a token asset between blockchain networks.
+Transfer a token asset between dYdX and Noble networks.
 
 #### Method Declaration
 
 :::code-group
 
 ```python [Python]
-
+# Coming soon.
 ```
 
 ```typescript [TypeScript]
-
+// Coming soon.
 ```
 
 ```rust [Rust]
@@ -26,22 +26,26 @@ pub async fn send_token_ibc(
 ```
 
 ```url [API]
+/ibc.applications.transfer.v1.Msg/Transfer
 ```
 
 :::
 
 :::details[Unification Plan]
+- Generalize to all IBC/blockchains.
+- Missing in Python.
+- Missing in TS: user required to produce the low-level message and then `post.send()` it.
 :::
 
 #### Parameters
 
 | Parameter         | Location  | Type          | Mandatory | Description                       |
 | ----------------- | --------- | ------------- | --------- | --------------------------------- |
-| `account`         | query     | [Account]     | true      | The account                       |
-| `sender`          | query     | [Address]     | true      | Address of the sender             |
-| `recipient`       | query     | [Address]     | true      | Address of the recipient          |
-| `token`           | query     | [Tokenized]   | true      |                                   |
-| `source_channel`  | query     | String        | true      |                                   |           
+| `account`         | query     | [Account]     | true      | The account.                      |
+| `sender`          | query     | [Address]     | true      | Address of the sender.            |
+| `recipient`       | query     | [Address]     | true      | Address of the recipient.         |
+| `token`           | query     | int           | true      | Token type and amount to transfer.|
+| `source_channel`  | query     | String        | true      | Source IBC relay channel.         |           
 
 
 

--- a/vocs-docs/docs/pages/node-client/private/transfer.mdx
+++ b/vocs-docs/docs/pages/node-client/private/transfer.mdx
@@ -18,7 +18,14 @@ async def transfer(
 ```
 
 ```typescript [TypeScript]
-TODO: transfer
+async transfer(
+  subaccount: SubaccountInfo,
+  recipientAddress: string,
+  recipientSubaccountNumber: number,
+  assetId: number,
+  amount: Long,
+  broadcastMode?: BroadcastMode,
+): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx>
 ```
 
 ```rust [Rust]
@@ -32,6 +39,7 @@ pub async fn transfer(
 ```
 
 ```url [API]
+/dydxprotocol.sending.Msg/CreateTransfer
 ```
 
 :::
@@ -51,9 +59,9 @@ pub async fn transfer(
 
 #### Response
 
-| Status | Meaning     | Schema |
-| ------ | ----------- | ------ |
-| `200`  | [OK]        | string |
+| Status | Meaning     | Schema   |
+| ------ | ----------- | -------- |
+| `200`  | [OK]        | [TxHash] |
 
 Examples: [Python] | [TypeScript] | [Rust]
 
@@ -63,3 +71,5 @@ Examples: [Python] | [TypeScript] | [Rust]
 
 [Wallet]: /types/wallet
 [SubaccountId]: /types/subaccount_id
+[OK]: /types/ok
+[TxHash]: /types/tx_hash

--- a/vocs-docs/docs/pages/node-client/private/withdraw.mdx
+++ b/vocs-docs/docs/pages/node-client/private/withdraw.mdx
@@ -18,7 +18,13 @@ async def withdraw(
 ```
 
 ```typescript [TypeScript]
-TODO: withdraw
+async withdraw(
+  subaccount: SubaccountInfo,
+  assetId: number,
+  quantums: Long,
+  recipient?: string,
+  broadcastMode?: BroadcastMode,
+): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx>
 ```
 
 ```rust [Rust]
@@ -32,6 +38,7 @@ pub async fn withdraw(
 ```
 
 ```url [API]
+/dydxprotocol.sending.Msg/WithdrawFromSubaccount
 ```
 
 :::
@@ -51,9 +58,9 @@ pub async fn withdraw(
 
 #### Response
 
-| Status | Meaning     | Schema |
-| ------ | ----------- | ------ |
-| `200`  | [OK]        | string |
+| Status | Meaning     | Schema   |
+| ------ | ----------- | -------- |
+| `200`  | [OK]        | [TxHash] |
 
 Examples: [Python] | [TypeScript] | [Rust]
 
@@ -64,3 +71,5 @@ Examples: [Python] | [TypeScript] | [Rust]
 
 [Wallet]: /types/wallet
 [SubaccountId]: /types/subaccount_id
+[OK]: /types/ok
+[TxHash]: /types/tx_hash


### PR DESCRIPTION
The pages where there, just not added to the `index.mdx` file.
Added also the Typescript method signatures and the Protobufs urls.