### PR TITLE
Fix Python WS orders class name

### DIFF
--- a/vocs-docs/docs/pages/indexer-client/websockets/orders.mdx
+++ b/vocs-docs/docs/pages/indexer-client/websockets/orders.mdx
@@ -9,7 +9,7 @@ Data feed of the orders of a market. Data contains lists of the bids and asks of
 :::code-group
 
 ```python [Python]
-# class `Orders`
+# class `OrderBook`
 def subscribe(self, market: str, batched: bool = True) -> Self
 def unsubscribe(self, market: str)
 ```


### PR DESCRIPTION
Ref https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-py-v2/dydx_v4_client/indexer/socket/websocket.py#L39